### PR TITLE
Ci/setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,32 @@ name: CI pipeline
 
 on:
   push:
-    branches: [ "main", "master", "dev" ]
+    branches: [ "main", "master", "dev", "ci/setup" ]
   pull_request:
-    branches: [ "main", "master", "dev" ]
+    branches: [ "main", "master", "dev", "ci/setup" ]
 
 jobs:
+  lint:
+    name: Lint Code
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service: [ backend/api-gateway, backend/auth-service, backend/user-service ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Golangci-lint
+        uses: golangci/golangci-lint-action@v9.2.0
+        with:
+          working-directory: ${{ matrix.service }}
+
   test:
     name: Run Tests
     runs-on: ubuntu-latest

--- a/backend/api-gateway/internal/cache/redis.go
+++ b/backend/api-gateway/internal/cache/redis.go
@@ -12,7 +12,7 @@ import (
 type RedisCache interface {
 	CheckRateLimit(ctx context.Context, ip string) (bool, error)
 	Ping(ctx context.Context) error
-	Close() error
+	Close()
 }
 
 type redisCache struct {
@@ -51,7 +51,9 @@ func (r *redisCache) Ping(ctx context.Context) error {
 	return r.cache.Ping(ctx).Err()
 }
 
-func (r *redisCache) Close() error {
+func (r *redisCache) Close() {
 	logger.Log.Info().Msg("closing redis cache connection")
-	return r.cache.Close()
+	if err := r.cache.Close(); err != nil {
+		logger.Log.Error().Err(err).Msg("error closing redis cache connection")
+	}
 }

--- a/backend/auth-service/internal/client/grpc/user_client.go
+++ b/backend/auth-service/internal/client/grpc/user_client.go
@@ -27,7 +27,7 @@ type UserClient struct {
 }
 
 func NewGRPCUserClient(addr string) (*UserClient, error) {
-	conn, err := grpc.Dial(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		return nil, err
 	}

--- a/backend/auth-service/internal/storage/postgres.go
+++ b/backend/auth-service/internal/storage/postgres.go
@@ -45,12 +45,16 @@ func NewPostgresGORM(ctx context.Context, cfg config.PostgresConfig) (*PostgresG
 	return &PostgresGORM{DB: db}, nil
 }
 
-func (p *PostgresGORM) Close() error {
+func (p *PostgresGORM) Close() {
 	sqlDB, err := p.DB.DB()
 	if err != nil {
-		return err
+		logger.Log.Fatal().Err(err).Msg("failed to close database connection.")
 	}
 
 	logger.Log.Info().Msg("Closing postgres connection...")
-	return sqlDB.Close()
+
+	if err := sqlDB.Close(); err != nil {
+		logger.Log.Fatal().Err(err).Msg("Error closing postgres connection.")
+	}
+	logger.Log.Info().Msg("Database connection closed.")
 }

--- a/backend/user-service/internal/storage/postgres.go
+++ b/backend/user-service/internal/storage/postgres.go
@@ -45,11 +45,16 @@ func NewPostgresGORM(ctx context.Context, cfg config.PostgresConfig) (*PostgresG
 	return &PostgresGORM{DB: db}, nil
 }
 
-func (p *PostgresGORM) Close() error {
+func (p *PostgresGORM) Close() {
 	sqlDB, err := p.DB.DB()
 	if err != nil {
-		return err
+		logger.Log.Fatal().Err(err).Msg("failed to close database connection.")
 	}
+
 	logger.Log.Info().Msg("Closing postgres connection...")
-	return sqlDB.Close()
+
+	if err := sqlDB.Close(); err != nil {
+		logger.Log.Fatal().Err(err).Msg("Error closing postgres connection.")
+	}
+	logger.Log.Info().Msg("Database connection closed.")
 }


### PR DESCRIPTION
This pull request introduces several improvements across the CI pipeline and backend services. The most significant changes include adding a lint job to the CI workflow, updating the connection closing logic for Redis and Postgres to improve error handling and logging, and correcting the gRPC client initialization in the auth service.

**CI/CD Pipeline Enhancements:**

* Added a `lint` job to the GitHub Actions workflow (`.github/workflows/ci.yml`) to run `golangci-lint` on multiple backend services, and included the `ci/setup` branch in CI triggers.

**Backend Service Improvements:**

* Updated the `Close` methods in both `backend/auth-service/internal/storage/postgres.go` and `backend/user-service/internal/storage/postgres.go` to remove error returns, add improved logging, and ensure fatal errors are logged if the database connection cannot be closed. [[1]](diffhunk://#diff-1cbd3e9ebd4253b71de6add4ee8a2d53d4baf5d25e15b3e15d77549d558d0b54L48-R59) [[2]](diffhunk://#diff-c6e8b9b0c98d223685fd64b3ea5f093cd5fd7e811c944b5b674550a085147acfL48-R59)
* Changed the `Close` method in `backend/api-gateway/internal/cache/redis.go` to remove the error return and add error logging if closing the Redis connection fails. [[1]](diffhunk://#diff-4a00a8e62b460feaadc03fb47a7b70a6826be897e078acffbf7a65a4c4fd913cL15-R15) [[2]](diffhunk://#diff-4a00a8e62b460feaadc03fb47a7b70a6826be897e078acffbf7a65a4c4fd913cL54-R58)

**Bug Fixes:**

* Fixed the gRPC client initialization in `backend/auth-service/internal/client/grpc/user_client.go` by replacing `grpc.Dial` with `grpc.NewClient`.